### PR TITLE
Changes to work better with OpenShift SCCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ npm run start
 ```
 npm run dev
 ```
+
+## Building using an s2i image
+
+```
+s2i build . centos/nodejs-6-centos7 pacman
+```

--- a/bin/server.js
+++ b/bin/server.js
@@ -12,7 +12,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '80');
+var port = normalizePort(process.env.PORT || '8080');
 app.set('port', port);
 
 /**

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,8 @@ RUN git clone https://github.com/font/pacman.git .
 # Install app dependencies
 RUN npm install
 
-# Expose port 80
-EXPOSE 80
+# Expose port 8080
+EXPOSE 8080
 
 # Run container
 CMD ["npm", "start"]

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,8 @@
-var service_host = process.env.MONGO_SERVICE_HOST
+var service_host = 'localhost'
+
+if(process.env.MONGO_SERVICE_HOST) {
+    service_host = process.env.MONGO_SERVICE_HOST
+}
 
 var database = {
     url: `mongodb://${service_host}:27017/pacman`,

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,7 @@
+var service_host = process.env.MONGO_SERVICE_HOST
+
 var database = {
-    url: 'mongodb://localhost:27017/pacman',
+    url: `mongodb://${service_host}:27017/pacman`,
     options: {
         replicaSet: 'rs0',
         readPreference: 'secondaryPreferred'

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,9 +3,12 @@ var service_host = process.env.MONGO_SERVICE_HOST
 var database = {
     url: `mongodb://${service_host}:27017/pacman`,
     options: {
-        replicaSet: 'rs0',
         readPreference: 'secondaryPreferred'
     }
 };
+
+if(process.env.MONGO_REPLICA_SET) {
+    database.options.replicaSet = process.env.MONGO_REPLICA_SET
+}
 
 exports.database = database;


### PR DESCRIPTION
- change default port back to 8080
- use MONGO_SERVICE_HOST variable for database connection
- Update database config to accept an env variable for replicaset, this allows the use of the same image for both replicaset-based deployments and single mongo host deployments.
- Add s2i build instructions to README